### PR TITLE
Handing pre-releases

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -75,13 +75,13 @@ rm -Rf $GIT_PATH
 
 # Clone GIT repository
 echo "Cloning GIT repository..."
-git clone $GIT_REPO $GIT_PATH --branch ${BRANCH} --single-branch
+git clone $GIT_REPO $GIT_PATH --branch ${BRANCH} --single-branch || exit "$?"
 
 # Run grunt
 echo "Running JS Build..."
 cd $GIT_PATH
 npm install
-npm run build
+npm run build || exit "$?"
 
 # Move into SVN directory
 cd $SVN_PATH


### PR DESCRIPTION
This changes should create the pre-release already on GitHub.

Also changed the question `PRESS [ENTER] TO RELEASE VERSION ${VERSION} USING BRANCH ${BRANCH}"`, since it isn't working on Linux, causing a "arg count" error making impossible stop the execution before start deploying.

Also `CTRL+C` it isn't a good way to exit this script, so I changed to:

```
You are about to release "${VERSION}" based in "${BRANCH}" GIT branch. Are you sure? [y/N] 
```

It's `No` by default, so it's easy to exit, not to mention that now is more safe.